### PR TITLE
[SCMO-9466] Change ComponentVerticle.registerSelfConfChangeListener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased]
+### Breaking changes
+- ComponentVerticle.registerSelfConfChangeListener accepts Handler<ConfigChanged> instead of Handler<JsonObject>
+
 ## [1.4.0] - 2020-12-30
 ### Added
 - Support for escape character \\ for dots in path in json extractor

--- a/vertx-bus/src/test/java/com/cloudentity/tools/vertx/bus/ConfigChangedTest.java
+++ b/vertx-bus/src/test/java/com/cloudentity/tools/vertx/bus/ConfigChangedTest.java
@@ -1,0 +1,64 @@
+package com.cloudentity.tools.vertx.bus;
+
+import com.cloudentity.tools.vertx.bus.ComponentVerticle.ConfigChanged;
+import io.vertx.core.json.JsonObject;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ConfigChangedTest {
+
+  @Test
+  public void hasChangedShouldReturnTrueOnSimpleAttrChange() {
+    // given
+    ConfigChanged configChanged = new ConfigChanged(new JsonObject().put("a", 100), new JsonObject().put("a", 200));
+
+    // when then
+    Assert.assertEquals(true, configChanged.hasChanged("a"));
+  }
+
+  @Test
+  public void hasChangedShouldReturnTrueOnNestedAttrChange() {
+    // given
+    ConfigChanged configChanged = new ConfigChanged(new JsonObject().put("a", new JsonObject().put("x", 100)), new JsonObject().put("a", new JsonObject().put("x", 200)));
+
+    // when then
+    Assert.assertEquals(true, configChanged.hasChanged("a"));
+    Assert.assertEquals(true, configChanged.hasChanged("a.x"));
+  }
+
+  @Test
+  public void hasChangedShouldReturnFalseOnNonExistingAttr() {
+    // given
+    ConfigChanged configChanged = new ConfigChanged(new JsonObject().put("a", 100), new JsonObject().put("a", 200));
+
+    // when then
+    Assert.assertEquals(false, configChanged.hasChanged("b"));
+  }
+
+  @Test
+  public void hasChangedShouldReturnOnNotChangedAttribute() {
+    // given
+    ConfigChanged configChanged = new ConfigChanged(new JsonObject().put("a", 100), new JsonObject().put("a", 100));
+
+    // when then
+    Assert.assertEquals(false, configChanged.hasChanged("a"));
+  }
+
+  @Test
+  public void hasChangedShouldReturnTrueOnAddedAttribute() {
+    // given
+    ConfigChanged configChanged = new ConfigChanged(new JsonObject(), new JsonObject().put("a", 200));
+
+    // when then
+    Assert.assertEquals(true, configChanged.hasChanged("a"));
+  }
+
+  @Test
+  public void hasChangedShouldReturnTrueOnRemovedAttribute() {
+    // given
+    ConfigChanged configChanged = new ConfigChanged(new JsonObject().put("a", 100), new JsonObject());
+
+    // when then
+    Assert.assertEquals(true, configChanged.hasChanged("a"));
+  }
+}


### PR DESCRIPTION
ComponentVerticle.registerSelfConfChangeListener accepts `Handler<ConfigChanged>` instead of `Handler<JsonObject>`. It is breaking change, but I found only one place (checking in authz, iam-services, api-gateway, permission service) that `registerSelfConfChangeListener` was used (in that case it was ignoring the argument so it still compiles).