### PR TITLE
spring-like references can use environment variables from 'env' config fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased]
+### Added
+- spring-like references can use environment variables from 'env' config fallback
+
 ## [1.8.0] - 2021-05-07
 ### Fixed
 - Deploy registries sequentially for VertxModuleTest

--- a/README.md
+++ b/README.md
@@ -518,6 +518,9 @@ After resolution, we end up with the following configuration:
 }
 ```
 
+>NOTE<br/>
+> Environment variables can be overridden also for spring-like references.
+
 ##### Replacing sensitive environment variable with configuration reference
 
 If an environment variable contains sensitive value (e.g. database password) we should read it from secure storage like Vault.

--- a/vertx-bus/src/test/java/com/cloudentity/tools/vertx/conf/ConfSpringlikeReferenceTest.java
+++ b/vertx-bus/src/test/java/com/cloudentity/tools/vertx/conf/ConfSpringlikeReferenceTest.java
@@ -21,6 +21,19 @@ public class ConfSpringlikeReferenceTest {
   }
 
   @Test
+  public void shouldReplaceSimpleSingleSpringlikeReferenceWithEnvFallback() {
+    // given
+    JsonObject env = new JsonObject().put("Y", "100");
+    JsonObject conf = new JsonObject().put("x","${Y}").put("env", env);
+
+    // when
+    JsonObject result = ConfSpringlikeReference.populateRefs(conf);
+
+    // then
+    assertEquals("100", result.getValue("x"));
+  }
+
+  @Test
   public void shouldReplaceSimpleSingleSpringlikeReferenceWithDefaultValue() {
     // given
     JsonObject conf = new JsonObject().put("x","${y:200}").put("y", 100);


### PR DESCRIPTION
Spring-like references can take value from environment variable. This change is introduce to make it consistent with `$env`.