### PR TITLE
SCMO-10151 Vulnerability Squashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,25 @@
-##[Unreleased]
+## [Unreleased]
+### Security
+- [CVE-2020-13949](https://nvd.nist.gov/vuln/detail/CVE-2020-13949)
+  - Solved by upgrading jaeger-client 1.2.0 -> 1.8.0 (transitively libthrift 0.13.0 -> 0.14.1)
+  - Avoiding importing tomcat-embed-core 8.5.46, with its new vulnerabilities, by setting overriding libthrift -> 0.16.0
+  - Upgraded okhttp mockwebserver version from 3.14.9 to 4.9.0 to match that imported by jaeger 1.8.0
+- [CVE-2020-29582](https://nvd.nist.gov/vuln/detail/CVE-2020-29582)
+  - Solved by upgrading kotlin-stdlib and kotlin-stdlib-common from 1.3.50 -> 1.4.32
+  - Note that kotlin-stdlib 1.4.10 and kotlin-stdlib-common 1.4.0 would have been imported by okhttp 4.9.0 above
+- [CVE-2022-21653](https://nvd.nist.gov/vuln/detail/CVE-2022-21653)
+  - Upgrading circe 0.11.1 to 0.14.1 to move keep transient scala-reflect vulnerabilities in test scope - moves jawn-parser 0.14.1 -> 1.1.2
+  - Upgrading jawn-parser -> 1.3.2 to solve vulnerability
+- [CVE-2018-12541](https://nvd.nist.gov/vuln/detail/CVE-2018-12541) - Solved by upgrading vertx 3.9.5 -> 3.9.12 (transitively netty-transport 4.1.49 -> 4.1.72)
+- [CVE-2021-21290](https://nvd.nist.gov/vuln/detail/CVE-2021-21290) - Solved by upgrading vertx 3.9.5 -> 3.9.12 (transitively netty-transport 4.1.49 -> 4.1.72)
+- [CVE-2021-21295](https://nvd.nist.gov/vuln/detail/CVE-2021-21295) - Solved by upgrading vertx 3.9.5 -> 3.9.12 (transitively netty-transport 4.1.49 -> 4.1.72)
+- [CVE-2021-21409](https://nvd.nist.gov/vuln/detail/CVE-2021-21409) - Solved by upgrading vertx 3.9.5 -> 3.9.12 (transitively netty-transport 4.1.49 -> 4.1.72)
+- [CVE-2021-37136](https://nvd.nist.gov/vuln/detail/CVE-2021-37136) - Solved by upgrading vertx 3.9.5 -> 3.9.12 (transitively netty-transport 4.1.49 -> 4.1.72)
+- [CVE-2021-37137](https://nvd.nist.gov/vuln/detail/CVE-2021-37137) - Solved by upgrading vertx 3.9.5 -> 3.9.12 (transitively netty-transport 4.1.49 -> 4.1.72)
+- [CVE-2021-43797](https://nvd.nist.gov/vuln/detail/CVE-2021-43797) - Solved by upgrading vertx 3.9.5 -> 3.9.12 (transitively netty-transport 4.1.49 -> 4.1.72)
+- [CVE-2021-29425](https://nvd.nist.gov/vuln/detail/CVE-2021-29425) - Solved by upgrading commons-io 2.5 -> 2.11.0
+- [CVE-2020-17521](https://nvd.nist.gov/vuln/detail/CVE-2020-17521) - Solved by upgrading rest-assured 3.3.0 -> 4.5.1 (transitively groovy 2.4.15 -> 3.0.9, httpclient 4.5.3 -> 4.5.13)
+- [CVE-2020-13956](https://nvd.nist.gov/vuln/detail/CVE-2020-13956) - Solved by upgrading rest-assured 3.3.0 -> 4.5.1 (transitively groovy 2.4.15 -> 3.0.9, httpclient 4.5.3 -> 4.5.13)
 
 ## [1.10.0] - 2021-11-17
 ### Changed

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,6 @@
     <jawn.version>1.3.2</jawn.version>
     <rest.assured.version>4.5.1</rest.assured.version>
     <logback.classic.version>1.2.0</logback.classic.version>
-    <owaspdt.url>https://owaspdt.int.cloudentity.com</owaspdt.url>
   </properties>
 
   <scm>
@@ -192,60 +191,6 @@
                 </goals>
               </execution>
             </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <activation>
-        <activeByDefault>false</activeByDefault>
-      </activation>
-      <id>owasp-dependency-track</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.cyclonedx</groupId>
-            <artifactId>cyclonedx-maven-plugin</artifactId>
-            <version>1.6.4</version>
-            <inherited>false</inherited>
-            <executions>
-              <execution>
-                <phase>deploy</phase>
-                <goals>
-                  <goal>makeAggregateBom</goal>
-                </goals>
-              </execution>
-            </executions>
-            <configuration>
-              <schemaVersion>1.1</schemaVersion>
-              <includeBomSerialNumber>true</includeBomSerialNumber>
-              <includeCompileScope>true</includeCompileScope>
-              <includeProvidedScope>true</includeProvidedScope>
-              <includeRuntimeScope>true</includeRuntimeScope>
-              <includeSystemScope>true</includeSystemScope>
-              <includeTestScope>false</includeTestScope>
-              <includeDependencyGraph>true</includeDependencyGraph>
-              <includeLicenseText>false</includeLicenseText>
-            </configuration>
-          </plugin>
-          <plugin>
-            <groupId>io.github.pmckeown</groupId>
-            <artifactId>dependency-track-maven-plugin</artifactId>
-            <version>0.8.1</version>
-            <inherited>false</inherited>
-            <executions>
-              <execution>
-                <phase>deploy</phase>
-                <goals>
-                  <goal>delete-project</goal>
-                  <goal>upload-bom</goal>
-                </goals>
-              </execution>
-            </executions>
-            <configuration>
-              <dependencyTrackBaseUrl>${owaspdt.url}</dependencyTrackBaseUrl>
-              <apiKey>${owaspdt.api.key}</apiKey>
-            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/pom.xml
+++ b/pom.xml
@@ -32,17 +32,17 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vertx.version>3.9.5</vertx.version>
+    <vertx.version>3.9.12</vertx.version>
     <java.version>1.8</java.version>
     <scala.version>2.12.9</scala.version>
     <scalaz.version>7.3.0-M10</scalaz.version>
-    <circe.version>0.11.1</circe.version>
-    <jaeger.version>1.2.0</jaeger.version>
+    <circe.version>0.14.1</circe.version>
+    <jaeger.version>1.8.0</jaeger.version>
     <embedded-consul.version>1.0.2</embedded-consul.version>
     <slf4j.version>1.7.30</slf4j.version>
     <junit.version>4.13.1</junit.version>
-    <okhttp3.mockserver.version>3.14.9</okhttp3.mockserver.version>
-    <rest.assured.version>3.3.0</rest.assured.version>
+    <okhttp3.version>4.9.3</okhttp3.version>
+    <rest.assured.version>4.5.1</rest.assured.version>
     <logback.classic.version>1.2.0</logback.classic.version>
     <owaspdt.url>https://owaspdt.int.cloudentity.com</owaspdt.url>
   </properties>
@@ -168,7 +168,7 @@
           <plugin>
             <groupId>org.owasp</groupId>
             <artifactId>dependency-check-maven</artifactId>
-            <version>6.0.3</version>
+            <version>6.5.3</version>
             <configuration>
               <skipProvidedScope>false</skipProvidedScope>
               <skipRuntimeScope>false</skipRuntimeScope>
@@ -433,7 +433,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.5</version>
+        <version>2.11.0</version>
       </dependency>
       <dependency>
         <groupId>commons-codec</groupId>
@@ -472,6 +472,31 @@
         <artifactId>jaeger-client</artifactId>
         <version>${jaeger.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.apache.thrift</groupId>
+        <artifactId>libthrift</artifactId>
+        <version>0.16.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>okhttp</artifactId>
+        <version>${okhttp3.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib</artifactId>
+        <version>1.4.32</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib-common</artifactId>
+        <version>1.4.32</version>
+      </dependency>
+      <dependency>
+        <groupId>org.typelevel</groupId>
+        <artifactId>jawn-parser_2.12</artifactId>
+        <version>1.3.2</version>
+      </dependency>
 
       <!--TEST-->
       <dependency>
@@ -489,7 +514,7 @@
       <dependency>
         <groupId>com.squareup.okhttp3</groupId>
         <artifactId>mockwebserver</artifactId>
-        <version>${okhttp3.mockserver.version}</version>
+        <version>${okhttp3.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,10 @@
     <embedded-consul.version>1.0.2</embedded-consul.version>
     <slf4j.version>1.7.30</slf4j.version>
     <junit.version>4.13.1</junit.version>
-    <okhttp3.version>4.9.3</okhttp3.version>
+    <okhttp3.mockserver.version>4.9.0</okhttp3.mockserver.version>
+    <libthrift.version>0.16.0</libthrift.version>
+    <kotlin.version>1.4.32</kotlin.version>
+    <jawn.version>1.3.2</jawn.version>
     <rest.assured.version>4.5.1</rest.assured.version>
     <logback.classic.version>1.2.0</logback.classic.version>
     <owaspdt.url>https://owaspdt.int.cloudentity.com</owaspdt.url>
@@ -475,27 +478,23 @@
       <dependency>
         <groupId>org.apache.thrift</groupId>
         <artifactId>libthrift</artifactId>
-        <version>0.16.0</version>
-      </dependency>
-      <dependency>
-        <groupId>com.squareup.okhttp3</groupId>
-        <artifactId>okhttp</artifactId>
-        <version>${okhttp3.version}</version>
+        <version>${libthrift.version}</version>
       </dependency>
       <dependency>
         <groupId>org.jetbrains.kotlin</groupId>
         <artifactId>kotlin-stdlib</artifactId>
-        <version>1.4.32</version>
+        <version>${kotlin.version}</version>
       </dependency>
       <dependency>
         <groupId>org.jetbrains.kotlin</groupId>
         <artifactId>kotlin-stdlib-common</artifactId>
-        <version>1.4.32</version>
+        <version>${kotlin.version}</version>
       </dependency>
+
       <dependency>
         <groupId>org.typelevel</groupId>
         <artifactId>jawn-parser_2.12</artifactId>
-        <version>1.3.2</version>
+        <version>${jawn.version}</version>
       </dependency>
 
       <!--TEST-->
@@ -514,7 +513,7 @@
       <dependency>
         <groupId>com.squareup.okhttp3</groupId>
         <artifactId>mockwebserver</artifactId>
-        <version>${okhttp3.version}</version>
+        <version>${okhttp3.mockserver.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -178,8 +178,8 @@
                 <format>HTML</format>
                 <format>JUNIT</format>
               </formats>
-              <cveUrlBase>https://nvdcve:MoKerviNeupTaTEr@nvdcve.artifactory.syntegrity.com/nvdcve-1.1-%d.json.gz</cveUrlBase>
-              <cveUrlModified>https://nvdcve:MoKerviNeupTaTEr@nvdcve.artifactory.syntegrity.com/nvdcve-1.1-modified.json.gz</cveUrlModified>
+              <cveUrlBase>https://freedumbytes.gitlab.io/setup/nist-nvd-mirror/nvdcve-1.1-%d.json.gz</cveUrlBase>
+              <cveUrlModified>https://freedumbytes.gitlab.io/setup/nist-nvd-mirror/nvdcve-1.1-modified.json.gz</cveUrlModified>
               <suppressionFiles>
                 <suppressionFile>https://raw.githubusercontent.com/cloudentity/security-gate/dev/owasp/dependency-check/project-suppression.xml</suppressionFile>
               </suppressionFiles>

--- a/vertx-server/src/main/scala/com/cloudentity/tools/vertx/server/api/routes/utils/Codecs.scala
+++ b/vertx-server/src/main/scala/com/cloudentity/tools/vertx/server/api/routes/utils/Codecs.scala
@@ -31,7 +31,7 @@ trait CirceVertxCodecs {
 
   implicit def encoder[A](implicit e: io.circe.Encoder[A]) =
     new VertxEncoder[A] {
-      override def encode(a: A): String = e(a).pretty(printer)
+      override def encode(a: A): String = e(a).printWith(printer)
     }
 }
 


### PR DESCRIPTION
## [Jira task](https://cloudentity.atlassian.net/browse/SCMO-10151)

## Description

* Upgraded various dependencies to squash vulnerabilities (see CHANGELOG for details)
* Upgraded `dependency-check-maven` plugin to 6.5.3
* Removed `owasp-dependency-track` plugin (Xray is used instead)

Related PRs:

* [vertx-tools](https://github.com/cloudentity/vertx-tools/pull/69)
* [orchis-jwt](https://github.com/cloudentity/orchis-jwt/pull/5)
* [orchis-tools-vertx](https://github.com/cloudentity/orchis-tools-vertx/pull/26)
* [messaging](https://github.com/cloudentity/messaging/pull/6)
* [overlay-tools-serializers](https://github.com/cloudentity/overlay-tools-serializers/pull/7)
* [overlay-tools-base](https://github.com/cloudentity/overlay-tools-base/pull/13)
* [openapi-clients](https://github.com/cloudentity/openapi-clients/pull/11)
* [pyron](https://github.com/cloudentity/pyron/pull/113)
* [security-gate](https://github.com/cloudentity/security-gate/pull/2)
* [iam-services](https://github.com/cloudentity/iam-services/pull/240)
* [authz-service](https://github.com/cloudentity/authz-service/pull/71)
* [permission-service](https://github.com/cloudentity/permission-service/pull/41)
* [orchis-devices](https://github.com/cloudentity/orchis-devices/pull/37)
* [orchis-api-gateway](https://github.com/cloudentity/orchis-api-gateway/pull/78)
* [orchis-tes](https://github.com/cloudentity/orchis-tes/pull/30)
* [localstack](https://github.com/cloudentity/localstack/pull/495)


## Type of changes
<!-- [Place an '[X]' (no spaces) in all applicable fields.] -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Tests (extending the test suite)
- [x] Refactor (internal improvement that doesn't change product functionality)
- [ ] Other (if none of the other choices apply)
